### PR TITLE
Enable normquant output register to cut critical path

### DIFF
--- a/rtl/neureka_engine.sv
+++ b/rtl/neureka_engine.sv
@@ -396,9 +396,10 @@ module neureka_engine #(
       end
 
       neureka_accumulator_normquant #(
-        .TP  ( TP_IN  ),
-        .AP  ( TP_OUT ),
-        .ACC ( 32     )
+        .TP               ( TP_IN  ),
+        .AP               ( TP_OUT ),
+        .ACC              ( 32     ),
+        .OUTREG_NORMQUANT ( 1      )
       ) i_accumulator (
         .clk_i       ( clk_i                                              ),
         .rst_ni      ( rst_ni                                             ),


### PR DESCRIPTION
This PR adapt the FSM of the accumulator in order to work with the latency introduced by a pipeline register in the normquant module. This register is useful to cut a critical path that may arise during the physical implementation of the design.

This PR is marked as a draft since two tasks still need to be performed:
- [x] Add parametric generation to distinguish the case when the register is instantiated and when it's not.
- [x] Check from P&R if timing issues have been solved.