### PR TITLE
Fix NEureka PEs grid configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ hw-all: hw-lib hw-compile hw-opt
 # Software stuff... to be moved?
 .PHONY: stimuli build-cleanup
 
+PE_H ?= 4
+PE_W ?= 4
 FS ?= 1
 ifeq ($(FS), 3)
   H_IN ?= 6
@@ -220,7 +222,7 @@ INC_FLAGS += $(addprefix -I,$(INC_DIRS))
 
 # Flags
 ACCELERATOR_UPPERCASE := $(shell echo $(ACCELERATOR) | tr [:lower:] [:upper:])
-APP_CFLAGS += -DNNX_ACCELERATOR=\"$(ACCELERATOR)\" -DNNX_$(ACCELERATOR_UPPERCASE) -DNNX_NEUREKA_TESTBENCH
+APP_CFLAGS += -DNNX_ACCELERATOR=\"$(ACCELERATOR)\" -DNNX_$(ACCELERATOR_UPPERCASE) -DNNX_NEUREKA_TESTBENCH -DNNX_NEUREKA_PE_H=$(PE_H) -DNNX_NEUREKA_PE_W=$(PE_W)
 # -DNEUREKA_WEIGHT_SOURCE_WMEM
 APP_CFLAGS += $(INC_FLAGS)
 APP_CFLAGS += $(NOPRINT_FLAG)
@@ -275,6 +277,8 @@ VSIM_DEPS=$(CRT)
 VSIM_PARAMS=-gPROB_STALL=$(P_STALL)   \
 	-gSTIM_INSTR=stim_instr.txt \
 	-gSTIM_DATA=stim_data.txt \
+	-gPE_H=$(PE_H) \
+	-gPE_W=$(PE_W) \
         -suppress vsim-3009
 
 # Run the simulation

--- a/regr/ci_regression.sh
+++ b/regr/ci_regression.sh
@@ -21,6 +21,10 @@ export N_PROC=20
 export P_STALL=0.04
 TIMEOUT=200
 
+export PE_H=4
+export PE_W=4
+echo "Running with config (H, W)=($PE_H, $PE_W)"
+
 # Declare a string array with type
 declare -a test_list=(
     "regr/basic.yml"
@@ -36,3 +40,5 @@ for val in "${test_list[@]}"; do
     fi
 done
 unset P_STALL
+unset PE_H
+unset PE_W

--- a/regr/conf_regression.sh
+++ b/regr/conf_regression.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright (C) 2020-2024 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Author: Luigi Ghionda (luigi.ghionda2@unibo.it)
+
+export N_PROC=20
+export P_STALL=0.04
+TIMEOUT=200
+
+# (H, W)
+PARAMS=(
+    2 2
+    3 3
+    4 4
+    5 5
+    4 8
+    6 6
+    4 2
+    2 4
+    3 4
+    4 3
+)
+
+# Declare a string array with type
+declare -a test_list=(
+    "regr/basic.yml"
+#    "regr/fs1.yml"
+)
+
+i=0
+while [[ $i -lt ${#PARAMS[@]} ]]; do
+    export PE_H=${PARAMS[$i]}
+    export PE_W=${PARAMS[$((i + 1))]}
+    i=$((i + 2))
+
+    echo "Running with config (H, W)=($PE_H, $PE_W)"
+
+    # Read the list values with space
+    for val in "${test_list[@]}"; do
+        nice -n10 regr/bwruntests.py --report_junit -t ${TIMEOUT} --yaml -o regr/neureka_tests.xml -p${N_PROC} --perf regr/perf.json $val
+        if test $? -ne 0; then
+            echo "Error in test $val with config (H, W)=($PE_H, $PE_W)"
+            exit 1
+        fi
+    done
+done
+unset P_STALL
+unset PE_H
+unset PE_W

--- a/rtl/array/neureka_binconv_array.sv
+++ b/rtl/array/neureka_binconv_array.sv
@@ -278,13 +278,13 @@ module neureka_binconv_array #(
 
         // filter size = 1
         localparam j_fs1  = (ii % PE_W);
-        localparam i_fs1  = ((ii-(ii%PE_H)) / PE_W);
+        localparam i_fs1  = ((ii-(ii%PE_W)) / PE_W);
 
         // filter size = 3
         localparam fj_fs3 = rr % 3;
         localparam fi_fs3 = (rr-fj_fs3)/ 3;
-        localparam j_fs3  = ii % PE_H + fj_fs3;
-        localparam i_fs3  = (ii-(ii%PE_H)) / PE_H + fi_fs3;
+        localparam j_fs3  = ii % PE_W + fj_fs3;
+        localparam i_fs3  = (ii-(ii%PE_W)) / PE_W + fi_fs3;
 
         for(genvar bb=0; bb<BLOCK_SIZE; bb++) begin : act_blk_gen
 

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -762,13 +762,13 @@ module neureka_ctrl #(
     implicit_padding_map[INFEAT_BUFFER_SIZE_HW-1:0] &= implicit_padding_map_temp[INFEAT_BUFFER_SIZE_HW-1:0];
   end : padding_from_incomplete_infeat
 
-  for(genvar i=0; i<INFEAT_BUFFER_SIZE_W; i++)begin
-    assign implicit_padding_map_temp[(i+1)*INFEAT_BUFFER_SIZE_W-1:i*INFEAT_BUFFER_SIZE_W] = {INFEAT_BUFFER_SIZE_W{h_size_in_map[i]}}; 
+  for(genvar i=0; i<INFEAT_BUFFER_SIZE_H; i++)begin
+    assign implicit_padding_map_temp[(i+1)*INFEAT_BUFFER_SIZE_W-1:i*INFEAT_BUFFER_SIZE_W] = {INFEAT_BUFFER_SIZE_W{h_size_in_map[i]}};
   end
 
-  logic [INFEAT_BUFFER_SIZE_W-1:0] t_explicit_padding_map;
+  logic [INFEAT_BUFFER_SIZE_H-1:0] t_explicit_padding_map;
   logic [INFEAT_BUFFER_SIZE_W-1:0] r_explicit_padding_map_r, r_explicit_padding_map;
-  logic [INFEAT_BUFFER_SIZE_W-1:0] b_explicit_padding_map_r, b_explicit_padding_map;
+  logic [INFEAT_BUFFER_SIZE_H-1:0] b_explicit_padding_map_r, b_explicit_padding_map;
   logic [INFEAT_BUFFER_SIZE_W-1:0] l_explicit_padding_map;
 
   assign t_explicit_padding_map   = (1 << config_.padding_top) - 1;
@@ -782,7 +782,7 @@ module neureka_ctrl #(
     explicit_padding_map encodes which of the 8x8 elements in the array are padded (0) and which ones are not (1).
   */
 
-  for(genvar i=0; i<INFEAT_BUFFER_SIZE_W; i++)begin
+  for(genvar i=0; i<INFEAT_BUFFER_SIZE_H; i++)begin
     assign t_explicit_padding_map_temp[(i+1)*INFEAT_BUFFER_SIZE_W-1:i*INFEAT_BUFFER_SIZE_W] = {INFEAT_BUFFER_SIZE_W{t_explicit_padding_map[i]}};
     assign b_explicit_padding_map_temp[(i+1)*INFEAT_BUFFER_SIZE_W-1:i*INFEAT_BUFFER_SIZE_W] = {INFEAT_BUFFER_SIZE_W{b_explicit_padding_map[i]}}; 
   end
@@ -876,14 +876,14 @@ module neureka_ctrl #(
                                                                                    (state!=LOAD && state!=WEIGHTOFFS && state!=MATRIXVEC && state!=STREAMIN) & state_change )):(state!=LOAD && state!=WEIGHTOFFS && state!=MATRIXVEC && state!=STREAMIN) & state_change ;
   end
 
-  // the NEUREKA array has 36 PEs -- one per each spatial pixel in the output space that it can support (3x3)
-  logic [PE_H-1:0] enable_pe_vert, enable_pe_horiz;
+  logic [PE_H-1:0] enable_pe_h;
+  logic [PE_W-1:0] enable_pe_w;
   logic [PE_H*PE_W-1:0] enable_pe_strided, pe_col_strided;
   logic [PE_H*PE_W-1:0] enable_pe, enable_pe_temp;
 
   // enable pe_cols depending on the subtile size considering residuals in the horizontal & vertical directions
-  assign enable_pe_vert  = (1 << h_size_out) - 1;
-  assign enable_pe_horiz = (1 << w_size_out) - 1;
+  assign enable_pe_h = (1 << h_size_out) - 1;
+  assign enable_pe_w = (1 << w_size_out) - 1;
 
   for(genvar h=0; h<PE_H; h++) begin : strided_output_height
     for(genvar w=0; w<PE_W; w++) begin : strided_output_width
@@ -909,9 +909,9 @@ module neureka_ctrl #(
   // overall column enable takes into account both horizontal and vertical enables, as well as strided mode
 
   for(genvar ii=0; ii<PE_H; ii++) begin
-    assign enable_pe_temp[(ii+1)*PE_W-1:ii*PE_W] = {PE_W{enable_pe_vert[ii]}};  
-  end 
-  assign enable_pe = {PE_H{enable_pe_horiz}} & enable_pe_temp & enable_pe_strided;
+    assign enable_pe_temp[(ii+1)*PE_W-1:ii*PE_W] = {PE_W{enable_pe_h[ii]}};
+  end
+  assign enable_pe = {PE_H{enable_pe_w}} & enable_pe_temp & enable_pe_strided;
 
   // compute last enabled PE
   logic [$clog2(NEUREKA_NUM_PE_MAX)-1:0] last_pe_d, last_pe_q;

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -41,7 +41,7 @@ package neureka_package;
   parameter int NEUREKA_INFEAT_BUFFER_SIZE_H_DEFAULT = -1; // NEUREKA_PE_H_DEFAULT+2; // Input Feature buffer size across height. 
   parameter int NEUREKA_INFEAT_BUFFER_SIZE_W_DEFAULT = -1; // NEUREKA_PE_W_DEFAULT+2; // Input Feature buffer size across width
   parameter int NEUREKA_INFEAT_BUFFER_SIZE_HW_DEFAULT = -1; // NEUREKA_INFEAT_BUFFER_SIZE_H_DEFAULT*NEUREKA_INFEAT_BUFFER_SIZE_W_DEFAULT; // Input Feature buffer size 
-  parameter int NEUREKA_INFEAT_BUFFER_SIZE_HW_MAX = 36; // Max. input buffer size currently considered
+  parameter int NEUREKA_INFEAT_BUFFER_SIZE_HW_MAX = 64; // Max. input buffer size currently considered
 
   // number of contexts
   parameter int NR_CONTEXT = 1;

--- a/rtl/verif/tb_neureka.sv
+++ b/rtl/verif/tb_neureka.sv
@@ -29,6 +29,8 @@ module tb_neureka;
   parameter int unsigned TP_OUT = NEUREKA_TP_OUT;
   parameter int unsigned BP = 9*NEUREKA_TP_OUT;
   parameter int unsigned MP = BP/NEUREKA_TP_OUT;
+  parameter int unsigned PE_H = 4;
+  parameter int unsigned PE_W = 4;
   parameter MEMORY_SIZE = 2*8192*3;
   parameter STACK_MEMORY_SIZE = 4*MEMORY_SIZE;
   parameter BASE_ADDR = 0;
@@ -222,14 +224,12 @@ module tb_neureka;
   endgenerate
 
   neureka_top_wrap #(
-    .TP_IN        ( TP_IN               ),
-    .TP_OUT       ( TP_OUT            ),
-    .CNT          ( TP_IN            ),
-    // .BW           (9*32),
-    // .MP           ( MP               ),
-    .ID           ( ID               ),
-    .PE_H         ( 4 ),
-    .PE_W         ( 4 )
+    .TP_IN          ( TP_IN          ),
+    .TP_OUT         ( TP_OUT         ),
+    .CNT            ( TP_IN          ),
+    .ID             ( ID             ),
+    .PE_H           ( PE_H           ),
+    .PE_W           ( PE_W           )
   ) i_dut (
     .clk_i          ( clk_i          ),
     .rst_ni         ( rst_ni         ),


### PR DESCRIPTION
This PR fixes PE grid configurations beyond the default 4×4, including non-square layouts such as 4×2 and 2×4.
The changes primarily affect the control logic, ensuring the correct processing elements are enabled and that input activations are dispatched appropriately for any given grid shape.

The (H, W) configuration of the PE grid is now passed as a parameter from the Makefile to the testbench, and is also used in the software dependency to properly handle tiling (see [here](https://github.com/pulp-platform/pulp-nnx/commit/3e79b0597c4f152e91f90238a55a280b8d32dc56)).

Originally made for NEureka-FT, it may be of general interest.