### PR TITLE
Substantial improvements to clock gating strategy

### DIFF
--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -966,8 +966,8 @@ module neureka_ctrl #(
   assign ctrl_engine.enable_accumulator = enable_pe;
 
   // control the accumulator's state or the norm/quant unit's state
-  assign ctrl_engine.ctrl_accumulator.clear          = (state==IDLE) | (state==STREAMOUT_DONE && state_change==1'b1);
-  assign ctrl_engine.ctrl_accumulator.clock_gating   = ~((state==LOAD) | (state==STREAMOUT && state_change==1'b1));
+  assign ctrl_engine.ctrl_accumulator.clear          = (state==IDLE && state_change==1'b1) | (state==STREAMOUT_DONE && state_change==1'b1);
+  assign ctrl_engine.ctrl_accumulator.clock_gating   = ~(state==LOAD | state==IDLE);
   assign ctrl_engine.ctrl_accumulator.clear_offset   = (state==IDLE) | (state==WEIGHTOFFS && state_change==1'b1);
   assign ctrl_engine.ctrl_accumulator.goto_normquant = ((state==NORMQUANT & ~config_.norm_option_shift) | (state==NORMQUANT_SHIFT)) & state_change;
   assign ctrl_engine.ctrl_accumulator.goto_accum     = (state==MATRIXVEC || state==WEIGHTOFFS) & state_change;

--- a/rtl/ctrl/neureka_ctrl_fsm.sv
+++ b/rtl/ctrl/neureka_ctrl_fsm.sv
@@ -80,7 +80,7 @@ module neureka_ctrl_fsm
   assign prefetch_matrixvec_done  = (prefetch_done_d & accum_done_d)|(prefetch_done_d & accum_done_q)|(prefetch_done_q & accum_done_d)|(prefetch_done_q & accum_done_q);
   
   state_aq_t accumulators_state;
-  assign accumulators_state = flags_engine_i.flags_accumulator[NUM_PE-1].state;
+  assign accumulators_state = flags_engine_i.flags_accumulator[config_i.last_pe].state;
 
   /* finite state machine */
   always_ff @(posedge clk_i or negedge rst_ni)

--- a/rtl/neureka_engine.sv
+++ b/rtl/neureka_engine.sv
@@ -244,12 +244,12 @@ module neureka_engine #(
     .NB_IN_STREAMS ( NR_PE          ),
     .DATA_WIDTH    ( NEUREKA_MEM_BANDWIDTH )
   ) i_serialize_store_out (
-    .clk_i   ( clk_i                 ),
-    .rst_ni  ( rst_ni                ),
-    .clear_i ( clear_i               ),
+    .clk_i   ( clk_i                           ),
+    .rst_ni  ( rst_ni                          ),
+    .clear_i ( clear_i | ctrl_i.clear_ser      ),
     .ctrl_i  ( ctrl_i.ctrl_serialize_streamout ),
-    .push_i  ( store_out_cols        ),
-    .pop_o   ( store_out             )
+    .push_i  ( store_out_cols                  ),
+    .pop_o   ( store_out                       )
   );
 
   // Streamin data goingo into the column accumulators comes per column and is deserialized
@@ -287,12 +287,12 @@ module neureka_engine #(
     .NB_OUT_STREAMS ( NR_PE          ),
     .DATA_WIDTH     ( NEUREKA_MEM_BANDWIDTH )
   ) i_deserialize_load_streamin (
-    .clk_i   ( clk_i                      ),
-    .rst_ni  ( rst_ni                     ),
-    .clear_i ( clear_i | ctrl_i.clear_des ),
-    .ctrl_i  ( ctrl_i.ctrl_serialize_streamin      ),
-    .push_i  ( load_streamin_fifo         ),
-    .pop_o   ( load_streamin_cols         )
+    .clk_i   ( clk_i                          ),
+    .rst_ni  ( rst_ni                         ),
+    .clear_i ( clear_i | ctrl_i.clear_des     ),
+    .ctrl_i  ( ctrl_i.ctrl_serialize_streamin ),
+    .push_i  ( load_streamin_fifo             ),
+    .pop_o   ( load_streamin_cols             )
   );
 
   // The same norm stream, coming simply from a FIFO, is shared between all columns.

--- a/rtl/neureka_engine.sv
+++ b/rtl/neureka_engine.sv
@@ -387,51 +387,32 @@ module neureka_engine #(
   /* Accumulators + Normalization/Quantization */
   generate
     for (genvar ii=0; ii<NR_PE; ii++) begin : accumulator_gen
-      localparam int unsigned LAST_PE = (ii==NR_PE-1) ? 1 : 0;
 
       ctrl_aq_t ctrl_accumulator;
-      if(LAST_PE) begin : last_gen
-        always_comb
-        begin
-          ctrl_accumulator = ctrl_i.ctrl_accumulator;
-          ctrl_accumulator.enable_streamout = ctrl_i.enable_accumulator[ii];
-          if(ctrl_i.enable_accumulator[ii] == '0) begin
-            ctrl_accumulator.goto_normquant        = '0;
-            ctrl_accumulator.goto_accum            = '0;
-            ctrl_accumulator.goto_streamin         = '0;
-            ctrl_accumulator.goto_streamout        = '0;
-            ctrl_accumulator.goto_idle             = '0;
-            ctrl_accumulator.ctrl_normquant        = '0;
-            ctrl_accumulator.weight_offset         = '0;
-            ctrl_accumulator.sample_shift          = '0;
-          end
+      always_comb
+      begin
+        ctrl_accumulator = ctrl_i.ctrl_accumulator;
+        ctrl_accumulator.enable_streamout = ctrl_i.enable_accumulator[ii];
+        if(ctrl_i.enable_accumulator[ii] == '0) begin
+          ctrl_accumulator.goto_normquant        = '0;
+          ctrl_accumulator.goto_accum            = '0;
+          ctrl_accumulator.goto_streamin         = '0;
+          ctrl_accumulator.goto_streamout        = '0;
+          ctrl_accumulator.goto_idle             = '0;
+          ctrl_accumulator.ctrl_normquant        = '0;
+          ctrl_accumulator.weight_offset         = '0;
+          ctrl_accumulator.sample_shift          = '0;
+        end
+        if(ctrl_i.last_pe == ii) begin
+          ctrl_accumulator.last_pe = 1'b1;
         end
       end
-      else begin : non_last_gen
-        always_comb
-        begin
-          ctrl_accumulator = ctrl_i.ctrl_accumulator;
-          ctrl_accumulator.enable_streamout = ctrl_i.enable_accumulator[ii];
-          if(ctrl_i.enable_accumulator[ii] == '0) begin
-            ctrl_accumulator.goto_normquant        = '0;
-            ctrl_accumulator.goto_accum            = '0;
-            ctrl_accumulator.goto_streamin         = '0;
-            ctrl_accumulator.goto_streamout        = '0;
-            ctrl_accumulator.goto_idle             = '0;
-            ctrl_accumulator.ctrl_normquant        = '0;
-            ctrl_accumulator.weight_offset         = '0;
-            ctrl_accumulator.sample_shift          = '0;
-          end
-        end
-      end
-
 
       neureka_accumulator_normquant #(
         .TP               ( TP_IN   ),
         .AP               ( TP_OUT  ),
         .ACC              ( 32      ),
-        .OUTREG_NORMQUANT ( 1       ),
-        .LAST_PE          ( LAST_PE )
+        .OUTREG_NORMQUANT ( 1       )
       ) i_accumulator (
         .clk_i       ( clk_i                                              ),
         .rst_ni      ( rst_ni                                             ),

--- a/rtl/neureka_engine.sv
+++ b/rtl/neureka_engine.sv
@@ -387,19 +387,51 @@ module neureka_engine #(
   /* Accumulators + Normalization/Quantization */
   generate
     for (genvar ii=0; ii<NR_PE; ii++) begin : accumulator_gen
+      localparam int unsigned LAST_PE = (ii==NR_PE-1) ? 1 : 0;
 
       ctrl_aq_t ctrl_accumulator;
-      always_comb
-      begin
-        ctrl_accumulator = ctrl_i.ctrl_accumulator;
-        ctrl_accumulator.enable_streamout = ctrl_i.enable_accumulator[ii];
+      if(LAST_PE) begin : last_gen
+        always_comb
+        begin
+          ctrl_accumulator = ctrl_i.ctrl_accumulator;
+          ctrl_accumulator.enable_streamout = ctrl_i.enable_accumulator[ii];
+          if(ctrl_i.enable_accumulator[ii] == '0) begin
+            ctrl_accumulator.goto_normquant        = '0;
+            ctrl_accumulator.goto_accum            = '0;
+            ctrl_accumulator.goto_streamin         = '0;
+            ctrl_accumulator.goto_streamout        = '0;
+            ctrl_accumulator.goto_idle             = '0;
+            ctrl_accumulator.ctrl_normquant        = '0;
+            ctrl_accumulator.weight_offset         = '0;
+            ctrl_accumulator.sample_shift          = '0;
+          end
+        end
+      end
+      else begin : non_last_gen
+        always_comb
+        begin
+          ctrl_accumulator = ctrl_i.ctrl_accumulator;
+          ctrl_accumulator.enable_streamout = ctrl_i.enable_accumulator[ii];
+          if(ctrl_i.enable_accumulator[ii] == '0) begin
+            ctrl_accumulator.goto_normquant        = '0;
+            ctrl_accumulator.goto_accum            = '0;
+            ctrl_accumulator.goto_streamin         = '0;
+            ctrl_accumulator.goto_streamout        = '0;
+            ctrl_accumulator.goto_idle             = '0;
+            ctrl_accumulator.ctrl_normquant        = '0;
+            ctrl_accumulator.weight_offset         = '0;
+            ctrl_accumulator.sample_shift          = '0;
+          end
+        end
       end
 
+
       neureka_accumulator_normquant #(
-        .TP               ( TP_IN  ),
-        .AP               ( TP_OUT ),
-        .ACC              ( 32     ),
-        .OUTREG_NORMQUANT ( 1      )
+        .TP               ( TP_IN   ),
+        .AP               ( TP_OUT  ),
+        .ACC              ( 32      ),
+        .OUTREG_NORMQUANT ( 1       ),
+        .LAST_PE          ( LAST_PE )
       ) i_accumulator (
         .clk_i       ( clk_i                                              ),
         .rst_ni      ( rst_ni                                             ),

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -326,6 +326,7 @@ package neureka_package;
     hwpe_stream_package::ctrl_serdes_t  ctrl_serialize_streamout;
     logic [NEUREKA_NUM_PE_MAX-1:0]      enable_accumulator;
     logic                               clear_des;
+    logic                               clear_ser;
     logic                               mode_linear;
     logic [$clog2(NEUREKA_NUM_PE_MAX)-1:0] last_pe;
   } ctrl_engine_t;

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -238,6 +238,7 @@ package neureka_package;
     logic [$clog2(QUANT_CNT_SIZE):0] qw;       // weights quantization
     logic                            enable_streamout;
     logic                            depthwise;
+    logic                            last_pe;
   } ctrl_aq_t;
 
   typedef enum {
@@ -326,6 +327,7 @@ package neureka_package;
     logic [NEUREKA_NUM_PE_MAX-1:0]      enable_accumulator;
     logic                               clear_des;
     logic                               mode_linear;
+    logic [$clog2(NEUREKA_NUM_PE_MAX)-1:0] last_pe;
   } ctrl_engine_t;
 
   typedef struct packed {
@@ -462,6 +464,7 @@ package neureka_package;
     logic        use_rounding;
     logic [4:0]  shift_reqnt;
     uloop_iter_neureka_t uloop_iter;
+    logic [$clog2(NEUREKA_NUM_PE_MAX)-1:0] last_pe;
   } config_neureka_t;
 
   typedef struct packed {


### PR DESCRIPTION
This PR introduces substantial improvements to clock gating of the accumulator & normquant units. In particular, this should impact the dynamic power consumption of the normalization multipliers, which are now fully gated except during the `NORMQUANT` stage.