### PR TITLE
Restore Reverted Commit (#31) and Improve Binconv Gating

### DIFF
--- a/rtl/array/neureka_binconv_array.sv
+++ b/rtl/array/neureka_binconv_array.sv
@@ -322,13 +322,16 @@ module neureka_binconv_array #(
         ctrl_pe.ctrl_col.invalidate = ctrl_i.ctrl_pe.ctrl_col.filter_mode == NEUREKA_FILTER_MODE_3X3_DW & ctrl_i.ctrl_pe.ctrl_col.weight_offset ? block_invalidate_q : 1'b0;
       end
 
+      logic  clk_en_gated;
+      assign clk_en_gated = ctrl_i.enable_pe[ii] &  ctrl_i.clock_gating;
+
       // column instantiation
       logic clk_gated;
       cluster_clock_gating i_hier_column_gate (
-        .clk_i     ( clk_i                                         ),
-        .en_i      ( enable_i & ctrl_i.enable_pe[ii] | clear_i     ),
-        .test_en_i ( test_mode_i                                   ),
-        .clk_o     ( clk_gated                                     )
+        .clk_i     ( clk_i                             ),
+        .en_i      ( enable_i & clk_en_gated | clear_i ),
+        .test_en_i ( test_mode_i                       ),
+        .clk_o     ( clk_gated                         )
       );
 
       neureka_binconv_pe #(

--- a/rtl/array/neureka_binconv_col.sv
+++ b/rtl/array/neureka_binconv_col.sv
@@ -45,13 +45,29 @@ module neureka_binconv_column #(
   output flags_binconv_block_t   flags_o
 );
 
+  logic enable_int, enable_dw, enable_d, enable_q;
+
+  assign enable_int = (ctrl_i.filter_mode==NEUREKA_FILTER_MODE_3X3_DW & ctrl_i.weight_offset) ? enable_dw : enable_i;
+
+  assign enable_dw = enable_i | enable_q;
+
   logic clk_gated;
   cluster_clock_gating i_hier_block_gate (
-    .clk_i     ( clk_i              ),
-    .en_i      ( enable_i | clear_i ),
-    .test_en_i ( test_mode_i        ),
-    .clk_o     ( clk_gated          )
+    .clk_i     ( clk_i                ),
+    .en_i      ( enable_int | clear_i ),
+    .test_en_i ( test_mode_i          ),
+    .clk_o     ( clk_gated            )
   );
+
+  assign enable_d = enable_i;
+  always_ff @(posedge clk_i or negedge rst_ni)
+  begin
+    if(~rst_ni) begin
+      enable_q <= '0;
+    end else begin
+      enable_q <= enable_d;
+    end
+  end
 
   ///////////////////////////////////////////
   // Local Params, Interfaces, and Signals //

--- a/rtl/array/neureka_binconv_pe.sv
+++ b/rtl/array/neureka_binconv_pe.sv
@@ -118,8 +118,8 @@ module neureka_binconv_pe #(
       begin
         ctrl_col = ctrl_i.ctrl_col;
         ctrl_col.scale_shift = ii/4; // used for 1x1
-        ctrl_col.dw_weight_offset = ctrl_i.enable_col[ii] | depthwise_accumulator_active;
-        ctrl_col.enable_block = ctrl_col.enable_block & ctrl_i.enable_col_pw[9*(ii_rem_4+1)-1:9*ii_rem_4];
+        ctrl_col.dw_weight_offset = ctrl_i.dw_weight_offset[ii] | depthwise_accumulator_active;
+        ctrl_col.enable_block = ctrl_i.ctrl_col.enable_block & ctrl_i.enable_col_pw[9*(ii_rem_4+1)-1:9*ii_rem_4] & {9{ctrl_i.enable_col[ii]}} | {9{depthwise_accumulator_active}};
       end
 
       neureka_binconv_column #(
@@ -140,7 +140,7 @@ module neureka_binconv_pe #(
         .flags_o      (                                                       )
       );
 
-      assign col_pres_data[ii] = ctrl_col.enable_block[0] ? col_pres[ii].data : '0;
+      assign col_pres_data[ii] = col_pres[ii].valid ? col_pres[ii].data : '0;
 
       assign column_pres_depthwise_o[ii].data  = col_pres[ii].data;
       assign column_pres_depthwise_o[ii].valid = depthwise_accumulator_active ? col_pres[0].valid : 0; 

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -979,10 +979,12 @@ module neureka_ctrl #(
   assign fs1_row_mask     = {{{1'b0}, {kin_onehot[31:24]}},{{1'b0}, {kin_onehot[23:16]}},{{1'b0}, {kin_onehot[15:8]}},{{1'b0}, {kin_onehot[7:0]}}};
   assign fs1_kin_col_mask = {8{((k_in_lim < 8) ? 4'b01 : (k_in_lim < 16) ? 4'b11 : (k_in_lim < 24) ? 4'b111 : 4'b1111)}};
   
-  assign ctrl_engine.ctrl_binconv_array.ctrl_pe.enable_col    = (config_.filter_mode == NEUREKA_FILTER_MODE_1X1) ? ((state==WEIGHTOFFS) ? 
-                                                                  (fs1_qw_col_mask & 32'h0F & fs1_kin_col_mask) : 
-                                                                  fs1_qw_col_mask & fs1_kin_col_mask) : 
-                                                                  (1 << k_in_lim) - 1;
+  assign ctrl_engine.ctrl_binconv_array.ctrl_pe.enable_col    = (config_.filter_mode == NEUREKA_FILTER_MODE_1X1) ? fs1_qw_col_mask & fs1_kin_col_mask : 
+                                                                                                                   (1 << k_in_lim) - 1;
+  assign ctrl_engine.ctrl_binconv_array.ctrl_pe.dw_weight_offset = (config_.filter_mode == NEUREKA_FILTER_MODE_1X1) ? ((state==WEIGHTOFFS) ? 
+                                                                   (fs1_qw_col_mask & 32'h0F & fs1_kin_col_mask) : 
+                                                                    fs1_qw_col_mask & fs1_kin_col_mask) : 
+                                                                    (1 << k_in_lim) - 1;
   assign ctrl_engine.ctrl_binconv_array.ctrl_pe.enable_col_pw = (config_.filter_mode == NEUREKA_FILTER_MODE_1X1) ?  fs1_row_mask : 
                                                                   '1;
 

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -951,6 +951,7 @@ module neureka_ctrl #(
   
   
   assign ctrl_engine.ctrl_binconv_array.enable_pe = enable_pe;
+  assign ctrl_engine.ctrl_binconv_array.clock_gating = (state==WEIGHTOFFS | state==MATRIXVEC);
 
   // block-level enables depend on the operating mode -- during WEIGHTOFFS, only 1; in 1x1 mode, as many as the weight_bits are; and in 3x3, all 9 according to the filter_mask_map
   assign ctrl_engine.ctrl_binconv_array.ctrl_pe.ctrl_col.enable_block  = ((state==LOAD || state==WEIGHTOFFS) && config_.filter_mode == NEUREKA_FILTER_MODE_1X1) ? '1 :

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -288,6 +288,7 @@ package neureka_package;
   typedef struct packed {
     ctrl_binconv_col_t                ctrl_col;
     logic [NEUREKA_BLOCK_SIZE-1:0]    enable_col;
+    logic [NEUREKA_BLOCK_SIZE-1:0]    dw_weight_offset;
     logic [4*NEUREKA_COLUMN_SIZE-1:0] enable_col_pw;
     logic                             dw_accum;
     logic [31:0]                      padding_value;

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -306,6 +306,7 @@ package neureka_package;
     ctrl_binconv_pe_t               ctrl_pe;
     logic [$clog2(NEUREKA_TP_IN):0] depthwise_len;
     logic [NEUREKA_NUM_PE_MAX-1:0]  enable_pe;
+    logic                           clock_gating;
     logic [1:0]                     filter_mode;
     logic                           mode_linear;
     logic                           weight_offset;


### PR DESCRIPTION
This PR addresses issue #31 by reintroducing the previously reverted binconv gating feature after resolving the issues that caused the rollback.
It also includes improvements to the overall binconv gating logic.