### PR TITLE
rtl: Move wildcard imports to module header

### DIFF
--- a/rtl/accumulator/neureka_accumulator_adder.sv
+++ b/rtl/accumulator/neureka_accumulator_adder.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_accumulator_adder #(
+module neureka_accumulator_adder import neureka_package::*; #(
   parameter int unsigned NADD = neureka_package::NEUREKA_TP_OUT,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned QNT = 32,

--- a/rtl/accumulator/neureka_accumulator_normquant.sv
+++ b/rtl/accumulator/neureka_accumulator_normquant.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_accumulator_normquant #(
+module neureka_accumulator_normquant import neureka_package::*; #(
   parameter int unsigned TP               = NEUREKA_TP_IN, // output filter size in bits/cycle
   parameter int unsigned AP               = NEUREKA_TP_OUT, // number of accumulators
   parameter int unsigned ACC              = NEUREKA_ACCUM_SIZE,

--- a/rtl/accumulator/neureka_normquant.sv
+++ b/rtl/accumulator/neureka_normquant.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_normquant #(
+module neureka_normquant import neureka_package::*; #(
   parameter int unsigned NMULT = 4,
   parameter int unsigned NMS = neureka_package::NORM_MULT_SIZE,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,

--- a/rtl/accumulator/neureka_normquant_bias.sv
+++ b/rtl/accumulator/neureka_normquant_bias.sv
@@ -20,10 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-
-module neureka_normquant_bias #(
+module neureka_normquant_bias import neureka_package::*; #(
   parameter int unsigned NADD = 8,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned QNT = 32,

--- a/rtl/accumulator/neureka_normquant_multiplier.sv
+++ b/rtl/accumulator/neureka_normquant_multiplier.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_normquant_multiplier #(
+module neureka_normquant_multiplier import neureka_package::*; #(
   parameter int unsigned NMS = neureka_package::NORM_MULT_SIZE,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned PIPE = 0

--- a/rtl/accumulator/neureka_normquant_shifter.sv
+++ b/rtl/accumulator/neureka_normquant_shifter.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_normquant_shifter #(
+module neureka_normquant_shifter import neureka_package::*; #(
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned INT = 33,
   parameter int unsigned OUTPUT_REGISTER = 0

--- a/rtl/array/neureka_binconv_array.sv
+++ b/rtl/array/neureka_binconv_array.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_binconv_array #(
+module neureka_binconv_array import neureka_package::*; #(
   parameter int unsigned COLUMN_SIZE          = NEUREKA_COLUMN_SIZE, // number of BinConv blocks per column (default 9)
   parameter int unsigned NR_PE                = NEUREKA_PE_HW_DEFAULT, // number of BinConv columns (default 9 -- same of size of BinConv columns!)
   parameter int unsigned BLOCK_SIZE           = NEUREKA_BLOCK_SIZE,  // number of SoP's per BinConv block (default 4)

--- a/rtl/array/neureka_binconv_col.sv
+++ b/rtl/array/neureka_binconv_col.sv
@@ -19,9 +19,8 @@
  * Authors (NE16): Francesco Conti <francesco.conti@greenwaves-technologies.com>
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
-import neureka_package::*;
 
-module neureka_binconv_column #(
+module neureka_binconv_column import neureka_package::*; #(
   parameter int unsigned BLOCK_SIZE = NEUREKA_BLOCK_SIZE,           
   parameter int unsigned COLUMN_SIZE= NEUREKA_COLUMN_SIZE,
   parameter int unsigned TP_IN      = NEUREKA_TP_IN,                

--- a/rtl/array/neureka_binconv_pe.sv
+++ b/rtl/array/neureka_binconv_pe.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_binconv_pe #(
+module neureka_binconv_pe import neureka_package::*; #(
   parameter int unsigned COLUMN_SIZE      = NEUREKA_COLUMN_SIZE,         // number of BinConv blocks per column (default 9)
   parameter int unsigned BLOCK_SIZE       = NEUREKA_BLOCK_SIZE,          // number of Binconv per block
   parameter int unsigned BC_COLBLOCK_SIZE = COLUMN_SIZE*BLOCK_SIZE,      // total number of binconv per PE

--- a/rtl/array/neureka_scale.sv
+++ b/rtl/array/neureka_scale.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_scale #(
+module neureka_scale import neureka_package::*; #(
   parameter int unsigned INP_ACC  =  8, // input bitwidth
   parameter int unsigned OUT_ACC  = 16, // output bitwidth
   parameter int unsigned N_SHIFTS =  8  // number of mutliplexed shifts

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -22,11 +22,11 @@
 
 `include "register_interface/typedef.svh"
 
+module neureka_ctrl
 import neureka_package::*;
 import hwpe_ctrl_package::*;
 import hci_package::*;
-
-module neureka_ctrl #(
+#(
   parameter int unsigned N_CORES = NR_CORES,
   parameter int unsigned ID      = ID_WIDTH,
   parameter int unsigned PE_H    = NEUREKA_PE_H_DEFAULT,

--- a/rtl/ctrl/neureka_ctrl_fsm.sv
+++ b/rtl/ctrl/neureka_ctrl_fsm.sv
@@ -20,11 +20,10 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
+module neureka_ctrl_fsm
 import neureka_package::*;
 import hwpe_ctrl_package::*;
 import hci_package::*;
-
-module neureka_ctrl_fsm
 #(
   parameter int unsigned NUM_PE = NEUREKA_NUM_PE_MAX
 )

--- a/rtl/input_buffer/neureka_double_input_buffer.sv
+++ b/rtl/input_buffer/neureka_double_input_buffer.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_double_infeat_buffer #(
+module neureka_double_infeat_buffer import neureka_package::*; #(
   parameter int unsigned INPUT_BUF_SIZE = 2048,
   parameter int unsigned BLOCK_SIZE     = NEUREKA_BLOCK_SIZE,
   parameter int unsigned DW             = NEUREKA_QA_IN,

--- a/rtl/input_buffer/neureka_input_buffer.sv
+++ b/rtl/input_buffer/neureka_input_buffer.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_infeat_buffer #(
+module neureka_infeat_buffer import neureka_package::*; #(
   parameter int unsigned INPUT_BUF_SIZE        = 2048,
   parameter int unsigned BLOCK_SIZE            = NEUREKA_BLOCK_SIZE,
   parameter int unsigned DW                    = NEUREKA_QA_IN,

--- a/rtl/input_buffer/neureka_input_buffer_newer.sv
+++ b/rtl/input_buffer/neureka_input_buffer_newer.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_infeat_buffer #(
+module neureka_infeat_buffer import neureka_package::*; #(
   parameter int unsigned INPUT_BUF_SIZE = 2048,
   parameter int unsigned BLOCK_SIZE     = NEUREKA_BLOCK_SIZE,
   parameter int unsigned DW             = NEUREKA_QA_IN

--- a/rtl/neureka_engine.sv
+++ b/rtl/neureka_engine.sv
@@ -21,9 +21,7 @@
  *                    Francesco Conti <f.conti@unibo.it>
  */
 
-import neureka_package::*;
-
-module neureka_engine #(
+module neureka_engine import neureka_package::*; #(
   parameter int unsigned COLUMN_SIZE    = NEUREKA_COLUMN_SIZE, // number of BinConv blocks per column (default 9)
   parameter int unsigned BLOCK_SIZE     = NEUREKA_BLOCK_SIZE,  // number of SoP's per BinConv block (default 4),
   parameter int unsigned TP_IN          = NEUREKA_TP_IN,       // number of input elements processed per cycle


### PR DESCRIPTION
Global wildcard imports may create name collision, as indicated in: https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#wildcard-import-of-packages