### PR TITLE
Fix FPGA synthesizability

### DIFF
--- a/rtl/accumulator/neureka_accumulator_adder.sv
+++ b/rtl/accumulator/neureka_accumulator_adder.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_accumulator_adder #(
+module neureka_accumulator_adder import neureka_package::*; #(
   parameter int unsigned NADD = neureka_package::NEUREKA_TP_OUT,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned QNT = 32,

--- a/rtl/accumulator/neureka_accumulator_normquant.sv
+++ b/rtl/accumulator/neureka_accumulator_normquant.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_accumulator_normquant #(
+module neureka_accumulator_normquant import neureka_package::*; #(
   parameter int unsigned TP               = NEUREKA_TP_IN, // output filter size in bits/cycle
   parameter int unsigned AP               = NEUREKA_TP_OUT, // number of accumulators
   parameter int unsigned ACC              = NEUREKA_ACCUM_SIZE,

--- a/rtl/accumulator/neureka_normquant.sv
+++ b/rtl/accumulator/neureka_normquant.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_normquant #(
+module neureka_normquant import neureka_package::*; #(
   parameter int unsigned NMULT = 4,
   parameter int unsigned NMS = neureka_package::NORM_MULT_SIZE,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,

--- a/rtl/accumulator/neureka_normquant_bias.sv
+++ b/rtl/accumulator/neureka_normquant_bias.sv
@@ -20,10 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-
-module neureka_normquant_bias #(
+module neureka_normquant_bias import neureka_package::*; #(
   parameter int unsigned NADD = 8,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned QNT = 32,

--- a/rtl/accumulator/neureka_normquant_multiplier.sv
+++ b/rtl/accumulator/neureka_normquant_multiplier.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_normquant_multiplier #(
+module neureka_normquant_multiplier import neureka_package::*; #(
   parameter int unsigned NMS = neureka_package::NORM_MULT_SIZE,
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned PIPE = 0

--- a/rtl/accumulator/neureka_normquant_shifter.sv
+++ b/rtl/accumulator/neureka_normquant_shifter.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_normquant_shifter #(
+module neureka_normquant_shifter import neureka_package::*; #(
   parameter int unsigned ACC = neureka_package::NEUREKA_ACCUM_SIZE,
   parameter int unsigned INT = 33,
   parameter int unsigned OUTPUT_REGISTER = 0

--- a/rtl/array/neureka_binconv_array.sv
+++ b/rtl/array/neureka_binconv_array.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_binconv_array #(
+module neureka_binconv_array import neureka_package::*; #(
   parameter int unsigned COLUMN_SIZE          = NEUREKA_COLUMN_SIZE, // number of BinConv blocks per column (default 9)
   parameter int unsigned NR_PE                = NEUREKA_PE_HW_DEFAULT, // number of BinConv columns (default 9 -- same of size of BinConv columns!)
   parameter int unsigned BLOCK_SIZE           = NEUREKA_BLOCK_SIZE,  // number of SoP's per BinConv block (default 4)

--- a/rtl/array/neureka_binconv_col.sv
+++ b/rtl/array/neureka_binconv_col.sv
@@ -19,9 +19,8 @@
  * Authors (NE16): Francesco Conti <francesco.conti@greenwaves-technologies.com>
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
-import neureka_package::*;
 
-module neureka_binconv_column #(
+module neureka_binconv_column import neureka_package::*; #(
   parameter int unsigned BLOCK_SIZE = NEUREKA_BLOCK_SIZE,           
   parameter int unsigned COLUMN_SIZE= NEUREKA_COLUMN_SIZE,
   parameter int unsigned TP_IN      = NEUREKA_TP_IN,                

--- a/rtl/array/neureka_binconv_pe.sv
+++ b/rtl/array/neureka_binconv_pe.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_binconv_pe #(
+module neureka_binconv_pe import neureka_package::*; #(
   parameter int unsigned COLUMN_SIZE      = NEUREKA_COLUMN_SIZE,         // number of BinConv blocks per column (default 9)
   parameter int unsigned BLOCK_SIZE       = NEUREKA_BLOCK_SIZE,          // number of Binconv per block
   parameter int unsigned BC_COLBLOCK_SIZE = COLUMN_SIZE*BLOCK_SIZE,      // total number of binconv per PE

--- a/rtl/array/neureka_scale.sv
+++ b/rtl/array/neureka_scale.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_scale #(
+module neureka_scale import neureka_package::*; #(
   parameter int unsigned INP_ACC  =  8, // input bitwidth
   parameter int unsigned OUT_ACC  = 16, // output bitwidth
   parameter int unsigned N_SHIFTS =  8  // number of mutliplexed shifts

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -20,11 +20,13 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
+`include "register_interface/typedef.svh"
+
+module neureka_ctrl
 import neureka_package::*;
 import hwpe_ctrl_package::*;
 import hci_package::*;
-
-module neureka_ctrl #(
+#(
   parameter int unsigned N_CORES = NR_CORES,
   parameter int unsigned ID      = ID_WIDTH,
   parameter int unsigned PE_H    = NEUREKA_PE_H_DEFAULT,

--- a/rtl/ctrl/neureka_ctrl_fsm.sv
+++ b/rtl/ctrl/neureka_ctrl_fsm.sv
@@ -20,11 +20,10 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
+module neureka_ctrl_fsm
 import neureka_package::*;
 import hwpe_ctrl_package::*;
 import hci_package::*;
-
-module neureka_ctrl_fsm
 #(
   parameter int unsigned NUM_PE = NEUREKA_NUM_PE_MAX
 )

--- a/rtl/input_buffer/neureka_double_input_buffer.sv
+++ b/rtl/input_buffer/neureka_double_input_buffer.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_double_infeat_buffer #(
+module neureka_double_infeat_buffer import neureka_package::*; #(
   parameter int unsigned INPUT_BUF_SIZE = 2048,
   parameter int unsigned BLOCK_SIZE     = NEUREKA_BLOCK_SIZE,
   parameter int unsigned DW             = NEUREKA_QA_IN,

--- a/rtl/input_buffer/neureka_input_buffer.sv
+++ b/rtl/input_buffer/neureka_input_buffer.sv
@@ -54,6 +54,12 @@ module neureka_infeat_buffer #(
   localparam AW = $clog2(NW);
   localparam DS = DW*BLOCK_SIZE;
 
+`ifdef TARGET_FPGA
+  localparam NEUREKA_BUFFER = neureka_package::BUFFER_FF;
+`else
+  localparam NEUREKA_BUFFER = neureka_package::BUFFER_LATCHES;
+`endif
+
   // Standard-cell memory based feature register
   logic                  scm_re;
   logic [AW-1:0]         scm_raddr;
@@ -71,9 +77,10 @@ module neureka_infeat_buffer #(
   logic [AW-1:0] vlen_cnt_fast_d, vlen_cnt_fast_q;
 
   neureka_infeat_buffer_scm_test_wrap #(
-    .ADDR_WIDTH ( AW ),
-    .DATA_WIDTH ( DS ),
-    .NUM_WORDS  ( NW )
+    .ADDR_WIDTH  ( AW             ),
+    .DATA_WIDTH  ( DS             ),
+    .NUM_WORDS   ( NW             ),
+    .USE_LATCHES ( NEUREKA_BUFFER )
   ) i_infeat_buffer_scm (
     .clk_i          ( clk_i            ),
     .rst_ni         ( rst_ni           ),

--- a/rtl/input_buffer/neureka_input_buffer.sv
+++ b/rtl/input_buffer/neureka_input_buffer.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_infeat_buffer #(
+module neureka_infeat_buffer import neureka_package::*; #(
   parameter int unsigned INPUT_BUF_SIZE        = 2048,
   parameter int unsigned BLOCK_SIZE            = NEUREKA_BLOCK_SIZE,
   parameter int unsigned DW                    = NEUREKA_QA_IN,

--- a/rtl/input_buffer/neureka_input_buffer_newer.sv
+++ b/rtl/input_buffer/neureka_input_buffer_newer.sv
@@ -20,9 +20,8 @@
  * Authors (NEUREKA): Arpan Suravi Prasad <prasadar@iis.ee.ethz.ch>
  */
 
-import neureka_package::*;
 
-module neureka_infeat_buffer #(
+module neureka_infeat_buffer import neureka_package::*; #(
   parameter int unsigned INPUT_BUF_SIZE = 2048,
   parameter int unsigned BLOCK_SIZE     = NEUREKA_BLOCK_SIZE,
   parameter int unsigned DW             = NEUREKA_QA_IN

--- a/rtl/input_buffer/neureka_input_buffer_scm.sv
+++ b/rtl/input_buffer/neureka_input_buffer_scm.sv
@@ -24,7 +24,8 @@ module neureka_infeat_buffer_scm
 #(
   parameter int unsigned ADDR_WIDTH   = 6,
   parameter int unsigned DATA_WIDTH   = 128,
-  parameter int unsigned NUM_WORDS    = 64
+  parameter int unsigned NUM_WORDS    = 64,
+  parameter int unsigned USE_LATCHES  = 0
 )
 (
   input  logic                                 clk_i,
@@ -48,31 +49,33 @@ module neureka_infeat_buffer_scm
 
   // Read address register, located at the input of the address decoder
   logic [NUM_WORDS-1:0][DATA_WIDTH-1:0] buffer;
-  logic [NUM_WORDS-1:0]  waddr_onehot;
-  logic [NUM_WORDS-1:0]  clk_we;
 
-  logic [DATA_WIDTH-1:0] wdata_q;
+  if(USE_LATCHES) begin : gen_latches
 
-  // ========================================================================
-  // WDATA SAMPLING
-  // ========================================================================
-  always_ff @(posedge clk_i or negedge rst_ni)
-  begin
-    if(~rst_ni)
-      wdata_q <= '0;
-    else if(clear_i)
-      wdata_q <= '0;
-    else if(we_i)
-      wdata_q <= wdata_i;
-  end
+    logic [NUM_WORDS-1:0]  waddr_onehot;
+    logic [NUM_WORDS-1:0]  clk_we;
 
-  // ========================================================================
-  // SCM (LATCHES)
-  // ========================================================================
+    logic [DATA_WIDTH-1:0] wdata_q;
 
-  // use the sampled address to select the correct rdata_o
-  // decode
-  generate
+    // ========================================================================
+    // WDATA SAMPLING
+    // ========================================================================
+    always_ff @(posedge clk_i or negedge rst_ni)
+    begin
+      if(~rst_ni)
+        wdata_q <= '0;
+      else if(clear_i)
+        wdata_q <= '0;
+      else if(we_i)
+        wdata_q <= wdata_i;
+    end
+
+    // ========================================================================
+    // SCM (LATCHES)
+    // ========================================================================
+
+    // use the sampled address to select the correct rdata_o
+    // decode
     for(genvar ii=0; ii<NUM_WORDS; ii++) begin : WADDR_DECODE
 
       always_comb
@@ -86,10 +89,8 @@ module neureka_infeat_buffer_scm
       end
 
     end
-  endgenerate
 
-  // generate one clock-gating cell for each register element
-  generate
+    // generate one clock-gating cell for each register element
     for(genvar ii=0; ii<NUM_WORDS; ii++) begin : CG_CELL_WORD_ITER
 
       cluster_clock_gating i_cg
@@ -101,9 +102,7 @@ module neureka_infeat_buffer_scm
       );
 
     end
-  endgenerate
 
-  generate
 
     for(genvar ii=0; ii<NUM_WORDS; ii++) begin : LATCH
 
@@ -116,7 +115,21 @@ module neureka_infeat_buffer_scm
 
     end
 
-  endgenerate
+  end else begin : gen_ff
+
+    always_ff @(posedge clk_i or negedge rst_ni)
+    begin
+      if(~rst_ni)
+        for (int i = 0; i < NUM_WORDS; i++)
+          buffer[i] <= '0;
+      else if(clear_i)
+        for (int i = 0; i < NUM_WORDS; i++)
+          buffer[i] <= '0;
+      else if(we_i)
+        buffer[waddr_i] <= wdata_i;
+    end
+
+  end
 
   assign infeat_buffer_o = buffer;
 

--- a/rtl/input_buffer/neureka_input_buffer_scm_test_wrap.sv
+++ b/rtl/input_buffer/neureka_input_buffer_scm_test_wrap.sv
@@ -24,7 +24,8 @@ module neureka_infeat_buffer_scm_test_wrap
 #(
   parameter int unsigned ADDR_WIDTH   = 6,
   parameter int unsigned DATA_WIDTH   = 128,
-  parameter int unsigned NUM_WORDS    = 64
+  parameter int unsigned NUM_WORDS    = 64,
+  parameter int unsigned USE_LATCHES  = 0
 )
 (
   input  logic                                 clk_i,
@@ -100,9 +101,10 @@ module neureka_infeat_buffer_scm_test_wrap
 
     neureka_infeat_buffer_scm
     #(
-      .ADDR_WIDTH     ( ADDR_WIDTH ),
-      .DATA_WIDTH     ( DATA_WIDTH ),
-      .NUM_WORDS      ( NUM_WORDS  )
+      .ADDR_WIDTH     ( ADDR_WIDTH  ),
+      .DATA_WIDTH     ( DATA_WIDTH  ),
+      .NUM_WORDS      ( NUM_WORDS   ),
+      .USE_LATCHES    ( USE_LATCHES )
     )
     neureka_infeat_buffer_scm_i
     (

--- a/rtl/neureka_engine.sv
+++ b/rtl/neureka_engine.sv
@@ -21,9 +21,7 @@
  *                    Francesco Conti <f.conti@unibo.it>
  */
 
-import neureka_package::*;
-
-module neureka_engine #(
+module neureka_engine import neureka_package::*; #(
   parameter int unsigned COLUMN_SIZE    = NEUREKA_COLUMN_SIZE, // number of BinConv blocks per column (default 9)
   parameter int unsigned BLOCK_SIZE     = NEUREKA_BLOCK_SIZE,  // number of SoP's per BinConv block (default 4),
   parameter int unsigned TP_IN          = NEUREKA_TP_IN,       // number of input elements processed per cycle

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -145,6 +145,11 @@ package neureka_package;
     flags_infeat_buffer_t flags_even_infeat_buffer;
   } flags_double_infeat_buffer_t;
 
+  typedef enum integer {
+    BUFFER_FF       = 0,
+    BUFFER_LATCHES  = 1
+  } regfile_e;
+
 
   // ========================================================================
   // SIGN_BUFFER related types


### PR DESCRIPTION
This PR fixes FPGA synthesizability by:

- Forcing the use of FF-based input buffer when targeting FPGA, through a define.
- Moving wildcard imports inside module header; this is necessary as in some Vivado flows it could result in packages being visible by other files, ending up with conflicting names.