### PR TITLE
Use new streamer interface with job queues

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -5,8 +5,8 @@ package:
     - "Francesco Conti <f.conti@unibo.it>"
 
 dependencies:
-  hwpe-stream:  { git: "https://github.com/pulp-platform/hwpe-stream.git", version: 1.8 }
-  hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 88a17cc6f00261d87bbfaeee54d4f107533c0c79 } # branch: fc/job-queues
+  hwpe-stream:  { git: "https://github.com/pulp-platform/hwpe-stream.git", rev: 35f6bb74b28acc5922262cf0244e7a7c7fe6a589 } # branch: master
+  hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 438f7b7ce6b8b464699f30290e2e33d559ba825b } # branch: fc/job-queues
   hwpe-ctrl:    { git: "https://github.com/pulp-platform/hwpe-ctrl.git", rev: "a596620" }
   zeroriscy:    { git: "https://github.com/yvantor/ibex.git", rev: "bender", target: "neureka_standalone" } # for verification only
  

--- a/Bender.yml
+++ b/Bender.yml
@@ -6,7 +6,7 @@ package:
 
 dependencies:
   hwpe-stream:  { git: "https://github.com/pulp-platform/hwpe-stream.git", version: 1.8 }
-  hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 7c11cc0e3f18329daabba38b5588e05e53b0497e } # branch: remove-automatic-parameter-prop
+  hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 88a17cc6f00261d87bbfaeee54d4f107533c0c79 } # branch: fc/job-queues
   hwpe-ctrl:    { git: "https://github.com/pulp-platform/hwpe-ctrl.git", rev: "a596620" }
   zeroriscy:    { git: "https://github.com/yvantor/ibex.git", rev: "bender", target: "neureka_standalone" } # for verification only
  

--- a/Bender.yml
+++ b/Bender.yml
@@ -5,7 +5,7 @@ package:
     - "Francesco Conti <f.conti@unibo.it>"
 
 dependencies:
-  hwpe-stream:  { git: "https://github.com/pulp-platform/hwpe-stream.git", rev: 35f6bb74b28acc5922262cf0244e7a7c7fe6a589 } # branch: master
+  hwpe-stream:  { git: "https://github.com/pulp-platform/hwpe-stream.git", version: 1.9.2 } # branch: master
   hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 438f7b7ce6b8b464699f30290e2e33d559ba825b } # branch: fc/job-queues
   hwpe-ctrl:    { git: "https://github.com/pulp-platform/hwpe-ctrl.git", rev: "a596620" }
   zeroriscy:    { git: "https://github.com/yvantor/ibex.git", rev: "bender", target: "neureka_standalone" } # for verification only

--- a/Bender.yml
+++ b/Bender.yml
@@ -6,7 +6,7 @@ package:
 
 dependencies:
   hwpe-stream:  { git: "https://github.com/pulp-platform/hwpe-stream.git", version: 1.9.2 } # branch: master
-  hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 438f7b7ce6b8b464699f30290e2e33d559ba825b } # branch: fc/job-queues
+  hci:          { git: "https://github.com/pulp-platform/hci.git", rev: 73e6f772881991313c93d232f1daddbac74731c0 } # branch: fc/job-queues
   hwpe-ctrl:    { git: "https://github.com/pulp-platform/hwpe-ctrl.git", rev: "a596620" }
   zeroriscy:    { git: "https://github.com/yvantor/ibex.git", rev: "bender", target: "neureka_standalone" } # for verification only
  

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -704,12 +704,12 @@ module neureka_ctrl #(
     a state transition (like in a Mealy FSM).
   */
 
-  assign ctrl_streamer.infeat_source_ctrl.req_start   = config_.prefetch ? prefetch_pulse | ((state==LOAD) & state_change) 
-                                                          :(state==LOAD) & state_change;
-  assign ctrl_streamer.weight_source_ctrl.req_start   = config_.streamin ? (state==MATRIXVEC & state_change) : (state==WEIGHTOFFS & state_change);
-  assign ctrl_streamer.norm_source_ctrl.req_start     = (state==NORMQUANT || state==NORMQUANT_BIAS || state==NORMQUANT_SHIFT)  & state_change;
-  assign ctrl_streamer.outfeat_sink_ctrl.req_start    = (state==STREAMOUT) & state_change;
-  assign ctrl_streamer.streamin_source_ctrl.req_start = (state==STREAMIN)  & state_change;
+  assign ctrl_streamer.infeat_source_ctrl.valid   = config_.prefetch ? prefetch_pulse | ((state==LOAD) & state_change) 
+                                                                     :                   (state==LOAD) & state_change;
+  assign ctrl_streamer.weight_source_ctrl.valid   = config_.streamin ? (state==MATRIXVEC & state_change) : (state==WEIGHTOFFS & state_change);
+  assign ctrl_streamer.norm_source_ctrl.valid     = (state==NORMQUANT || state==NORMQUANT_BIAS || state==NORMQUANT_SHIFT)  & state_change;
+  assign ctrl_streamer.outfeat_sink_ctrl.valid    = (state==STREAMOUT) & state_change;
+  assign ctrl_streamer.streamin_source_ctrl.valid = (state==STREAMIN)  & state_change;
 
   /*
     Set the streamer muxes / demuxes according to the current operating state.

--- a/rtl/ctrl/neureka_ctrl.sv
+++ b/rtl/ctrl/neureka_ctrl.sv
@@ -512,6 +512,8 @@ module neureka_ctrl #(
   assign ctrl_streamer.infeat_source_ctrl.addressgen_ctrl.d1_stride     = config_.infeat_d1_stride;
   assign ctrl_streamer.infeat_source_ctrl.addressgen_ctrl.d1_len        = config_.filter_mode == NEUREKA_FILTER_MODE_1X1 ? PE_H : INFEAT_BUFFER_SIZE_H;
   assign ctrl_streamer.infeat_source_ctrl.addressgen_ctrl.d2_stride     = config_.infeat_d2_stride; // currently unused
+  assign ctrl_streamer.infeat_source_ctrl.addressgen_ctrl.d2_len        = '0;
+  assign ctrl_streamer.infeat_source_ctrl.addressgen_ctrl.d3_stride     = '0;
   assign ctrl_streamer.infeat_source_ctrl.addressgen_ctrl.dim_enable_1h =  '1;
 
   /*
@@ -539,6 +541,8 @@ module neureka_ctrl #(
   assign ctrl_streamer.weight_source_ctrl.addressgen_ctrl.d1_stride     = config_.weights_d1_stride;
   assign ctrl_streamer.weight_source_ctrl.addressgen_ctrl.d1_len        = config_.filter_mode == NEUREKA_FILTER_MODE_1X1 ? 1 : '1;
   assign ctrl_streamer.weight_source_ctrl.addressgen_ctrl.d2_stride     = config_.weights_d2_stride;
+  assign ctrl_streamer.weight_source_ctrl.addressgen_ctrl.d2_len        = '0;
+  assign ctrl_streamer.weight_source_ctrl.addressgen_ctrl.d3_stride     = '0;
   assign ctrl_streamer.weight_source_ctrl.addressgen_ctrl.dim_enable_1h = dim_enable_1h_weights;
 
   /*
@@ -605,6 +609,8 @@ module neureka_ctrl #(
   assign ctrl_streamer.outfeat_sink_ctrl.addressgen_ctrl.d1_stride     = config_.outfeat_d1_stride;
   assign ctrl_streamer.outfeat_sink_ctrl.addressgen_ctrl.d1_len        = PE_W;
   assign ctrl_streamer.outfeat_sink_ctrl.addressgen_ctrl.d2_stride     = config_.outfeat_d2_stride;
+  assign ctrl_streamer.outfeat_sink_ctrl.addressgen_ctrl.d2_len        = '0;
+  assign ctrl_streamer.outfeat_sink_ctrl.addressgen_ctrl.d3_stride     = '0;
   assign ctrl_streamer.outfeat_sink_ctrl.addressgen_ctrl.dim_enable_1h = '1;
 
   /*
@@ -680,6 +686,8 @@ module neureka_ctrl #(
   assign ctrl_streamer.norm_source_ctrl.addressgen_ctrl.d1_stride     = '0;
   assign ctrl_streamer.norm_source_ctrl.addressgen_ctrl.d1_len        = '0;
   assign ctrl_streamer.norm_source_ctrl.addressgen_ctrl.d2_stride     = '0;
+  assign ctrl_streamer.norm_source_ctrl.addressgen_ctrl.d2_len        = '0;
+  assign ctrl_streamer.norm_source_ctrl.addressgen_ctrl.d3_stride     = '0;
   assign ctrl_streamer.norm_source_ctrl.addressgen_ctrl.dim_enable_1h =  2;
 
 

--- a/rtl/neureka_package.sv
+++ b/rtl/neureka_package.sv
@@ -365,19 +365,19 @@ package neureka_package;
     logic                            clear_source;
     logic                            clear_sink;
     logic                            wmem_sel;
-    hci_package::hci_streamer_ctrl_t infeat_source_ctrl;
-    hci_package::hci_streamer_ctrl_t weight_source_ctrl;
-    hci_package::hci_streamer_ctrl_t wmem_source_ctrl;
-    hci_package::hci_streamer_ctrl_t norm_source_ctrl;
-    hci_package::hci_streamer_ctrl_t outfeat_sink_ctrl;
-    hci_package::hci_streamer_ctrl_t streamin_source_ctrl;
+    hci_package::hci_streamer_v2_ctrl_t infeat_source_ctrl;
+    hci_package::hci_streamer_v2_ctrl_t weight_source_ctrl;
+    hci_package::hci_streamer_v2_ctrl_t wmem_source_ctrl;
+    hci_package::hci_streamer_v2_ctrl_t norm_source_ctrl;
+    hci_package::hci_streamer_v2_ctrl_t outfeat_sink_ctrl;
+    hci_package::hci_streamer_v2_ctrl_t streamin_source_ctrl;
   } ctrl_streamer_t;
 
   typedef struct packed {
-    hci_package::hci_streamer_flags_t feat_source_flags;
-    hci_package::hci_streamer_flags_t weight_source_flags;
-    hci_package::hci_streamer_flags_t norm_source_flags;
-    hci_package::hci_streamer_flags_t conv_sink_flags;
+    hci_package::hci_streamer_v2_flags_t feat_source_flags;
+    hci_package::hci_streamer_v2_flags_t weight_source_flags;
+    hci_package::hci_streamer_v2_flags_t norm_source_flags;
+    hci_package::hci_streamer_v2_flags_t conv_sink_flags;
     logic tcdm_fifo_empty;
   } flags_streamer_t;
 

--- a/rtl/neureka_streamer.sv
+++ b/rtl/neureka_streamer.sv
@@ -60,8 +60,8 @@ module neureka_streamer
   localparam int unsigned EW  = `HCI_SIZE_GET_EW(tcdm);
   localparam int unsigned EHW = `HCI_SIZE_GET_EHW(tcdm);
 
-  hci_streamer_ctrl_t  all_source_ctrl, wmem_source_ctrl;
-  hci_streamer_flags_t all_source_flags, wmem_source_flags;
+  hci_streamer_v2_ctrl_t  all_source_ctrl, wmem_source_ctrl;
+  hci_streamer_v2_flags_t all_source_flags, wmem_source_flags;
   flags_fifo_t tcdm_fifo_flags;
   flags_fifo_t tcdm_weight_fifo_flags;
 
@@ -203,7 +203,7 @@ module neureka_streamer
   assign wmem_enable = (~ctrl_i.ld_st_mux_sel & ctrl_i.wmem_sel & (ctrl_i.ld_which_mux_sel == LD_WEIGHT_SEL)) | (ctrl_i.ld_which_mux_sel == LD_FEAT_WEIGHT_SEL);
   assign all_source_enable = (~ctrl_i.ld_st_mux_sel & (~wmem_enable)) | (ctrl_i.ld_which_mux_sel == LD_FEAT_WEIGHT_SEL);
 
-  hci_core_source #(
+  hci_core_source_v2 #(
     .PASSTHROUGH_FIFO      ( 1                     ),
     .`HCI_SIZE_PARAM(tcdm) ( `HCI_SIZE_PARAM(tcdm) )
   ) i_all_source (
@@ -218,7 +218,7 @@ module neureka_streamer
     .flags_o     ( all_source_flags              )
   );
 
-  hci_core_source #(
+  hci_core_source_v2 #(
     .PASSTHROUGH_FIFO      ( 1                     ),
     .`HCI_SIZE_PARAM(tcdm) ( `HCI_SIZE_PARAM(tcdm) )
   ) i_weight_source (
@@ -233,7 +233,7 @@ module neureka_streamer
     .flags_o     ( wmem_source_flags             )
   );
 
-  hci_core_sink #(
+  hci_core_sink_v2 #(
     .`HCI_SIZE_PARAM(tcdm) ( `HCI_SIZE_PARAM(tcdm) )
   ) i_sink (
     .clk_i       ( clk_i                       ),


### PR DESCRIPTION
This pull request updates the NEUREKA project to use the latest `hwpe-stream` and `hci` dependencies, and migrates the codebase to use the new v2 streamer interfaces and modules. It also adapts the control logic to work with the new interface, including renaming control signals and initializing additional fields. These changes improve compatibility and prepare the codebase for new features and bug fixes from upstream projects.

Dependency updates:

* Updated `hwpe-stream` to version 1.9.2 and `hci` to a new commit on the `fc/job-queues` branch in `Bender.yml`, ensuring the latest features and bug fixes are included.

Migration to v2 streamer interface:

* Replaced all uses of `hci_streamer_ctrl_t` and related types with their v2 counterparts (`hci_streamer_v2_ctrl_t`, `hci_streamer_v2_flags_t`) in `neureka_package.sv`, `neureka_streamer.sv`, and corresponding module instantiations. [[1]](diffhunk://#diff-361b2d1c11d27e243bf73666df1b7a9dec0446ff83bce780b2f687c0e0b7f0daL368-R380) [[2]](diffhunk://#diff-e9f4d846d97f45e30b88f38f510a9e4e1afe70fce78615e5df98cf531b2cd924L63-R64) [[3]](diffhunk://#diff-e9f4d846d97f45e30b88f38f510a9e4e1afe70fce78615e5df98cf531b2cd924L206-R206) [[4]](diffhunk://#diff-e9f4d846d97f45e30b88f38f510a9e4e1afe70fce78615e5df98cf531b2cd924L221-R221) [[5]](diffhunk://#diff-e9f4d846d97f45e30b88f38f510a9e4e1afe70fce78615e5df98cf531b2cd924L236-R236)

Control logic and interface adjustments:

* Updated assignments in `neureka_ctrl.sv` to initialize new fields (`d2_len`, `d3_stride`) in the v2 streamer control structures for various data paths. [[1]](diffhunk://#diff-b2bc76b6712c7744d9b3658962bc52599339960d3c9aac1e521a7b359c2fc06fR515-R516) [[2]](diffhunk://#diff-b2bc76b6712c7744d9b3658962bc52599339960d3c9aac1e521a7b359c2fc06fR544-R545) [[3]](diffhunk://#diff-b2bc76b6712c7744d9b3658962bc52599339960d3c9aac1e521a7b359c2fc06fR612-R613) [[4]](diffhunk://#diff-b2bc76b6712c7744d9b3658962bc52599339960d3c9aac1e521a7b359c2fc06fR689-R690)
* Renamed control signals from `req_start` to `valid` to match the v2 streamer interface, and updated their logic accordingly in `neureka_ctrl.sv`.